### PR TITLE
docs(readme): point at .dot-secrets/MIGRATION.md for employer changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,11 @@ There's no central registry to update. `bin/dot` finds the `install.sh` on its n
 
 ## Private configuration
 
-Anything machine-specific or credential-bearing belongs in a private `~/.dot-secrets` repository, not here. Templates for the expected file layout are in [`templates/dot-secrets/`](templates/dot-secrets/). Topics that consume secrets (currently `kubernetes/`, `dbeaver/`, `robo3t/`) check for `~/.dot-secrets` during their install and fail with a clear message if it's missing.
+Anything machine-specific or credential-bearing belongs in a private `~/.dot-secrets` repository, not here. Templates for the expected file layout are in [`templates/dot-secrets/`](templates/dot-secrets/). Topics that consume secrets (currently `kubernetes/`, `dbeaver/`, `robo3t/`, `git/`, `myke/`, plus `lint/` for repo-wide PII guards) check for `~/.dot-secrets` during their install and fail with a clear message if it's missing.
+
+### Changing employers
+
+When you change companies, the only edits should be inside `~/.dot-secrets/` — the public dotfiles repo stays employer-agnostic. The full playbook (which file to update, delete, or keep, and the verification commands to run afterwards) lives in `~/.dot-secrets/MIGRATION.md`. If you ever find yourself reaching to edit something *here* for an employer-specific reason, that's a signal the value should move into `.dot-secrets` instead.
 
 ## Testing
 


### PR DESCRIPTION
## Summary

Adds a 'Changing employers' subsection under 'Private configuration' pointing at the migration playbook in `~/.dot-secrets/MIGRATION.md`. Also expands the list of topics that source from `.dot-secrets` to reflect the recent additions (`git/`, `myke/`, `lint/`) alongside the existing `kubernetes/`, `dbeaver/`, `robo3t/`.

The playbook itself stays in the private repo because the checklist inevitably names specific employers / clusters / tools — public-repo-unfriendly content. Public README just points at it.

## Companion PR

[helmedeiros/dot-secrets#1](https://github.com/helmedeiros/dot-secrets/pull/1) — adds the actual MIGRATION.md plus the per-topic config files.

## Test plan

- [x] `./test/run_tests.sh` — 380 green, 0 failed.
- [x] `gitleaks detect --no-banner` — no leaks found.